### PR TITLE
Increase size of Buildbot caches

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -88,7 +88,9 @@ config = {
     # Data lifetime
     # (http://docs.buildbot.net/0.8.12/manual/cfg-global.html#data-lifetime)
     'buildhorizon': 10000,
+    'cachedbuildrequests': 1000,
     'cachedbuilds': 600,
+    'cachedchanges': 200,
     'eventhorizon': 2000,
     'loghorizon': 5000
     }
@@ -878,5 +880,10 @@ c['buildHorizon'] = config['buildhorizon']
 c['logHorizon'] = config['loghorizon']
 c['eventHorizon'] = config['eventhorizon']
 c['caches'] = {
-    'Builds': config['cachedbuilds']
+    'BuildRequests': config['cachedbuildrequests'],
+    'Builds': config['cachedbuilds'],
+    'Changes': config['cachedchanges'],
+    'chdicts': config['cachedchanges'],
+    'SourceStamps': config['cachedbuildrequests'],
+    'ssdicts': config['cachedbuildrequests']
     }


### PR DESCRIPTION
I think it might be useful to let the buildmaster cache more objects. The defaults seem awfully low to me. I'd like to propose new settings:

- **BuildRequests=200**: The [Buildbot documentation][bbcaches] recommends that `BuildRequests` be "higher than the typical number of outstanding build requests." Right now, I'm counting something like 100 outstanding requests on our buildmaster. (The default setting is 1, which the documentation implies is some sort of reasonable "let us figure it out" default.)

- **Changes=100**: The documentation also recommends increasing `Changes` when using a DVCS:

  > This should be larger than the number of changes that typically arrive in the span of a few minutes, otherwise your schedulers will be reloading changes from the database every time they run. For distributed version control systems, like Git or Hg, several thousand changes may arrive at once, so setting this parameter to something like 10000 isn't unreasonable.

  I'm not expecting thousand-commit pushes, but I've certainly seen committers push dozens of commits. (The default is only 10.)

Do these new settings seem okay? I don't know how much memory the buildmaster's host has.

[bbcaches]: http://docs.buildbot.net/0.8.12/manual/cfg-global.html#caches