### PR TITLE
buildbot: send failure email also to the committer

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -826,6 +826,7 @@ def portWatcherMessageFormatter(mode, name, build, results, master_status):
         if maintainers_to_notify:
             text.append('\nResponsible maintainers:\n\t- {}'.format('\n\t- '.join(sorted(maintainers_to_notify))))
             interested_users.update(maintainers_to_notify)
+        interested_users.update(build.getResponsibleUsers())
 
         # links to individual builds
         text.append('\nLinks to individual build jobs:')


### PR DESCRIPTION
I don't have the buildbot master running at the moment, but maybe a simple change like this will fix the problem of committers not being notified about buildbot failures.

If anyone is able to test this before I set up the master myself again.

Please note that the buildbot already sends emails to committers by default, it's just that we are probably overriding that somewhere. So an alternative approach is to append maintainers to the list of recipients rather than erasing the list first.

Something like replacing

```python
        dl = [defer.maybeDeferred(self.lookup.getAddress, user)
              for user in self.interested_users]
```

with

```python
        dl = [defer.maybeDeferred(self.lookup.getAddress, user)
              for user in self.interested_users + build.getResponsibleUsers()]
```

might work as well. (I don't know if those two use the same type of data structure.)