### PR TITLE
Include name of buildslave in notification subject

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -784,7 +784,7 @@ class PortsMailNotifier(status.MailNotifier, object):
 def portWatcherMessageFormatter(mode, name, build, results, master_status):
     interested_users = set()
     result = util.Results[results]
-    subject = 'Build {}'.format(result.title())
+    subject = 'Build {} on {}'.format(result.title(), build.getSlavename())
     text = list()
     text.append('Status:       {}'.format(result.title()))
     text.append('Build slave:  {}'.format(build.getSlavename()))


### PR DESCRIPTION
When I receive multiple mails after a push, I would like to directly see which mail is for which macOS version.

This is untested, but I am confident it will work.