### PR TITLE
port_binary_distributable: Accept +var1+var2

### DIFF
--- a/jobs/port_binary_distributable.tcl
+++ b/jobs/port_binary_distributable.tcl
@@ -282,6 +282,14 @@ proc check_licenses {portName variantInfo verbose} {
     return 0
 }
 
+proc split_variants {variants} {
+    set result {}
+    set l [regexp -all -inline -- {([-+])([[:alpha:]_]+[\w\.]*)} $variants]
+    foreach { match sign variant } $l {
+        lappend result $variant $sign
+    }
+    return $result
+}
 
 # Begin
 
@@ -328,9 +336,10 @@ set ::argv [lrange $::argv 1 end]
 
 array set variantInfo {}
 foreach variantSetting $::argv {
-    set flag [string index $variantSetting 0]
-    set variantName [string range $variantSetting 1 end]
-    set variantInfo($variantName) $flag
+    set variant [split_variants $variantSetting]
+    foreach {variantName flag} $variant {
+        set variantInfo($variantName) $flag
+    }
 }
 
 exit [check_licenses $portName [array get variantInfo] $verbose]


### PR DESCRIPTION
port_binary_distributable currently expects all variants to be
space-separated, which does not equal to what port(1) accepts. Unify
them so that we can get accurate license info for variants in mpbb.

Note that some ports *do* change their licenses in variants. A popular
example is ffmpeg.