### PR TITLE
buildbot: Guarantee stable order of builds

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -445,10 +445,13 @@ def make_build_url(props):
 class TriggerWithPortlist(steps.Trigger):
     def getSchedulersAndProperties(self):
         sp = []
+        priority = 1
         for scheduler in self.schedulerNames:
             for port in self.build.getProperty('subportlist').split():
                 props = self.set_properties.copy()
                 props['portname'] = port
+                props['priority'] = priority
+                priority += 1
                 sp.append([scheduler, props])
         return sp
 
@@ -841,6 +844,19 @@ if 'man' in config['deploy']:
 
 ####### BUILDER CONFIGURATION #######
 
+def getPriority(request):
+    if request.properties and request.properties.hasProperty('priority'):
+        return int(request.properties.getProperty('priority'))
+    else:
+        return math.inf
+
+def getNextBuildOnPortBuilder(builder, requests):
+    nextBuild = requests[0]
+    for request in requests:
+        if getPriority(request) < getPriority(nextBuild):
+            nextBuild = request
+    return nextBuild
+
 # XXX: slavenames assignment should be automatic and more generic
 portsslaves = {}
 baseslaves = {}
@@ -881,6 +897,7 @@ for plat in build_platforms:
                 slavenames=['ports-' + plat],
                 factory=portbuilder_factory,
                 tags=['portbuilder', os_version],
+                nextBuild=getNextBuildOnPortBuilder,
                 env=merge_dicts(env_buildinfo, {'PATH': path_ports}))
             ))
 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/52766

In order to completely fix the issue we additionally need to generate a list of topologically sorted ports.