### PR TITLE
Define tools using a variable prefix

### DIFF
--- a/jobs/mprsyncup
+++ b/jobs/mprsyncup
@@ -58,11 +58,9 @@ STAT="${MPBIN}/gstat"
 BASENAME="/usr/bin/basename"
 TCLSH="${MPBIN}/port-tclsh"
 PORTINDEX="${PREFIX}/bin/portindex"
+PORTINDEX2JSON="${CONTRIB}/portindex2json/portindex2json.tcl"
 
 PATH=${PREFIX}/bin:/bin:/usr/bin:/usr/sbin:/opt/local/bin
-
-# Files to be used
-PORTINDEX2JSON=${CONTRIB}/portindex2json/portindex2json.tcl
 
 # Platforms we generate indexes for. This is intentionally split on
 # whitespace later.

--- a/jobs/mprsyncup
+++ b/jobs/mprsyncup
@@ -39,23 +39,25 @@ RBASE=${GITROOT}/release/base
 PORTS=${GITROOT}/release/ports
 CONTRIB=${GITROOT}/release/contrib
 RSYNCROOT=/rsync/macports
+MPTOOLSPREFIX=/opt/local
+MPBIN=${MPTOOLSPREFIX}/bin
 
 # Commands we need. For options to be substituted correctly, these must
 # not be substituted within double quotes. Thus, there must not be any
 # globbing characters, and the command itself must not contain spaces.
-GIT="/opt/local/bin/git"
-RSYNC="/opt/local/bin/rsync -q"
+GIT="${MPBIN}/git"
+RSYNC="${MPBIN}/rsync -q"
 RM="/bin/rm"
 MKDIR="/bin/mkdir"
-MV="/opt/local/bin/gmv"
+MV="${MPBIN}/gmv"
 LN="/bin/ln"
 TAR="/usr/bin/tar"
 OPENSSL="/usr/bin/openssl"
 AWK="/usr/bin/awk"
-STAT="/opt/local/bin/gstat"
+STAT="${MPBIN}/gstat"
 BASENAME="/usr/bin/basename"
-TCLSH="/opt/local/bin/port-tclsh"
-PORTINDEX=${PREFIX}/bin/portindex
+TCLSH="${MPBIN}/port-tclsh"
+PORTINDEX="${PREFIX}/bin/portindex"
 
 PATH=${PREFIX}/bin:/bin:/usr/bin:/usr/sbin:/opt/local/bin
 

--- a/jobs/mprsyncup
+++ b/jobs/mprsyncup
@@ -30,6 +30,16 @@
 set -e
 set -x
 
+# Paths we'll work on:
+ROOT=/var/tmp/macports
+PREFIX=${ROOT}/opt/local
+GITROOT=/var/tmp/macports
+TBASE=${GITROOT}/trunk/base
+RBASE=${GITROOT}/release/base
+PORTS=${GITROOT}/release/ports
+CONTRIB=${GITROOT}/release/contrib
+RSYNCROOT=/rsync/macports
+
 # Commands we need. For options to be substituted correctly, these must
 # not be substituted within double quotes. Thus, there must not be any
 # globbing characters, and the command itself must not contain spaces.
@@ -45,16 +55,6 @@ AWK="/usr/bin/awk"
 STAT="/opt/local/bin/gstat"
 BASENAME="/usr/bin/basename"
 TCLSH="/opt/local/bin/port-tclsh"
-
-# Paths we'll work on:
-ROOT=/var/tmp/macports
-PREFIX=${ROOT}/opt/local
-GITROOT=/var/tmp/macports
-TBASE=${GITROOT}/trunk/base
-RBASE=${GITROOT}/release/base
-PORTS=${GITROOT}/release/ports
-CONTRIB=${GITROOT}/release/contrib
-RSYNCROOT=/rsync/macports
 PORTINDEX=${PREFIX}/bin/portindex
 
 PATH=${PREFIX}/bin:/bin:/usr/bin:/usr/sbin:/opt/local/bin


### PR DESCRIPTION
This is a relatively trivial change with no (intended) side-effects, it just avoids repetition of hardcoded `/opt/local/bin`. Feel free to either suggest better names for variables, merge, or close if it's not worth merging.