### PR TITLE
mprsyncup: Add latest commit hash from macports-ports to PortIndex.JSON

### DIFF
--- a/jobs/mprsyncup
+++ b/jobs/mprsyncup
@@ -200,7 +200,7 @@ if [ "${PORTS_CHANGED}" -eq 1 ]; then
         # generate json for each platform-specific index
         for PLATFORM in $PLATFORMS; do
             INDEX="PortIndex_darwin_${PLATFORM}"
-            ${TCLSH} "${PORTINDEX2JSON}" "${INDEX}"/PortIndex > "${INDEX}"/PortIndex.json &
+            ${TCLSH} "${PORTINDEX2JSON}" "${INDEX}"/PortIndex --info commit="${PORTS_NEW_REV}" > "${INDEX}"/PortIndex.json &
         done
         wait
     )


### PR DESCRIPTION
`portindex2json.tcl` can now accept some custom keys. Passing with it the hash of the commit till which it has been updated would be beneficial.

It is also required by [macports-webapp](https://github.com/macports/macports-webapp).