### PR TITLE
All livecheck job to buildbot

### DIFF
--- a/buildbot/config.json.sample
+++ b/buildbot/config.json.sample
@@ -38,6 +38,8 @@
             "sshknownhostsfile": "ssh_known_hosts",
             "destpath": ""
         },
+        "livecheck": {
+        },
         "mirror": {
             "distfilesdir": ""
         }

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -360,6 +360,16 @@ if 'portindex' in config['deploy']:
             builderNames=['jobs-portindex'])
         ))
 
+if 'livecheck' in config['deploy']:
+    c['schedulers'].append(
+        schedulers.Nightly(
+            name='livecheck',
+            branch='master',
+            builderNames=['jobs-livecheck'],
+            hour=3,
+            minute=0)
+        )
+
 if 'mirror' in config['deploy']:
     c['schedulers'].append(
         schedulers.Triggerable(
@@ -885,6 +895,17 @@ if 'man' in config['deploy']:
                 srcpath='doc/*.html',
                 destpath=config['deploy']['man']['destpath'])))
 
+if 'livecheck' in config['deploy']:
+    jobs_livecheck_factory = util.BuildFactory()
+    jobs_livecheck_factory.addStep(steps.ShellCommand(
+        # TODO: make sure to use jobs_mirror_prefix
+        command=['port', '-v', 'livecheck', 'all'],
+        name='livecheck',
+        description=['running', 'livecheck'],
+        descriptionDone=['run', 'livecheck'],
+        env={'PATH': path_jobs},
+        warnOnFailure=True,
+        failOnFailure=False))
 
 ####### BUILDER CONFIGURATION #######
 
@@ -976,6 +997,14 @@ if 'man' in config['deploy']:
             slavenames=['jobs'],
             factory=jobs_man_factory,
             tags=['jobs', 'docs', 'man'],
+            env=merge_dicts(env_buildinfo, {'PATH': path_jobs})))
+if 'livecheck' in config['deploy']:
+    c['builders'].append(
+        util.BuilderConfig(
+            name='jobs-livecheck',
+            slavenames=['jobs'],
+            factory=jobs_livecheck_factory,
+            tags=['jobs', 'livecheck'],
             env=merge_dicts(env_buildinfo, {'PATH': path_jobs})))
 if 'mirror' in config['deploy']:
     c['builders'].append(


### PR DESCRIPTION
I still need to perform some testing, but I would like to ask for some general feedback nonetheless.

I would like to run livecheck on the buildbot on regular basis to get a list of outdated port and show those in the new app.

The approach that I just submitted might be somewhat problematic as it might block other jobs for too long. Should I create another builder on the same slave? Any further suggestions?