### PR TITLE
Add portversion property to builds

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -585,13 +585,18 @@ def make_portwatcher_factory(triggerable):
 
 # -- Port Builder --
 
+@util.renderer
+def get_port_command_with_prefix(props):
+    path = [prefix, 'bin', 'port']
+    return '/'.join(path)
+
 portbuilder_factory = util.BuildFactory()
 portbuilder_factory.useProgress = False
 portbuilder_factory.workdir = '../build'
 logdir = os.path.join(portbuilder_factory.workdir, 'logs')
 
 portbuilder_factory.addStep(steps.SetPropertyFromCommand(
-    command=['port', 'info', '--version', '--line', util.Interpolate('%(prop:portname)s')],
+    command=[get_port_command_with_prefix, 'info', '--version', '--line', util.Interpolate('%(prop:portname)s')],
     property='portversion'))
 
 portbuilder_factory.addStep(steps.Compile(


### PR DESCRIPTION
This is a prerequisite for https://github.com/macports/macports-webapp/issues/135

The first commit has been tested under buildbot 2.x a while ago, I haven't tested it under 0.8 yet.
The second commit is a pure speculation that tries to use the `port` command with the correct prefix.

See: https://trac.macports.org/ticket/56028