### PR TITLE
containers/paste: Always pull base image

### DIFF
--- a/containers/paste/deploy.sh
+++ b/containers/paste/deploy.sh
@@ -43,7 +43,7 @@ if [ "$IMAGES" -gt 0 ]; then
 fi
 
 printf "Rebuilding container %s with tag %s\n" "$CONTAINERNAME" "$NEWREV-$TIMESTAMP"
-docker build --no-cache -t "$CONTAINERNAME:$NEWREV-$TIMESTAMP" .
+docker build --pull --no-cache -t "$CONTAINERNAME:$NEWREV-$TIMESTAMP" .
 
 printf "Rebuild successful, tagging as %s:latest\n" "$CONTAINERNAME"
 docker tag "$CONTAINERNAME:$NEWREV-$TIMESTAMP" "$CONTAINERNAME:latest"


### PR DESCRIPTION
Use docker build --pull to always check for and download a newer base image if available.

See also macports/macports-smtpselfservice#1.