### PR TITLE
distributable_lib: add LLGPL license

### DIFF
--- a/jobs/distributable_lib.tcl
+++ b/jobs/distributable_lib.tcl
@@ -21,7 +21,7 @@ set check_deptypes [list depends_build depends_lib]
 set good_licenses [list afl agpl apache apsl artistic autoconf beopen bitstreamvera \
                    boost bsd bsd-old cc-by cc-by-sa cddl cecill cecill-b cecill-c cnri copyleft \
                    cpl curl epl fpll fontconfig freetype gd gfdl gpl \
-                   gplconflict ibmpl ijg isc jasper lgpl libtool lppl mit \
+                   gplconflict ibmpl ijg isc jasper lgpl libtool llgpl lppl mit \
                    mpl ncsa noncommercial openldap openssl permissive php \
                    psf public-domain qpl restrictive/distributable ruby \
                    sleepycat ssleay tcl/tk vim w3c wtfpl wxwidgets x11 zlib zpl]


### PR DESCRIPTION
Same as LGPL 2.1 but [for Lisp](https://opensource.franz.com/preamble.html).

Closes: https://trac.macports.org/ticket/70038