### PR TITLE
distributable_lib: only check depends_lib

### DIFF
--- a/jobs/distributable_lib.tcl
+++ b/jobs/distributable_lib.tcl
@@ -3,7 +3,7 @@
 # Library code for checking if ports are binary distributable.
 # Used by the port_binary_distributable tool.
 
-set check_deptypes [list depends_build depends_lib]
+set check_deptypes [list depends_lib]
 
 # Notes:
 # 'Restrictive/Distributable' means a non-free license that nonetheless allows


### PR DESCRIPTION
Checking depends_build results in many false positives due to unrelated build dependencies deep down in a port's dependency tree. License compatibility should only be determined by libraries and not build tools.

Some of the common build dependencies that cause this problem:

- perl (because of gdbm)
- python27 (because of openssl11)
- vala (because of graphviz)