### PR TITLE
Revert "honour license_noconflict in dependencies as well as the top-…

### DIFF
--- a/jobs/distributable_lib.tcl
+++ b/jobs/distributable_lib.tcl
@@ -334,14 +334,9 @@ proc check_licenses {portName variantInfo} {
             }
         }
 
-        # skip deps that are explicitly stated to not conflict
-        array unset aPort_noconflict_ports
-        foreach noconflict_port [lindex $aPortInfo 3] {
-            set aPort_noconflict_ports($noconflict_port) 1
-        }
         # add its deps to the list
         foreach possiblyNewPort [lindex $aPortInfo 0] {
-            if {![info exists portSeen($possiblyNewPort)] && ![info exists aPort_noconflict_ports($possiblyNewPort)]} {
+            if {![info exists portSeen($possiblyNewPort)]} {
                 lappend portList $possiblyNewPort
                 set portSeen($possiblyNewPort) 1
             }


### PR DESCRIPTION
…level port"

This reverts commit ea1a5037695e27580d4fc0ea28821ceb18a3ac15.

This fixes a top port being considered distributable if a dependency sets license_noconflict for a port, despite that port having a license conflict with the top port.